### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV FILEBEAT_VERSION=6.2.1
 ENV FILEBEAT_DIR=filebeat-${FILEBEAT_VERSION}-linux-x86_64
 ENV FILEBEAT_FILE=${FILEBEAT_DIR}.tar.gz
 ENV TARGET_DIR=/opt/filebeat
-
+ENV UDP_INTERNAL_PORT=30000
 RUN apk update && \
     apk add ca-certificates curl openssl && \
     update-ca-certificates && \
@@ -15,9 +15,11 @@ RUN apk update && \
 	rm ${FILEBEAT_FILE} && \
 	mkdir ${TARGET_DIR}/conf && \
 	cp ${TARGET_DIR}/filebeat.yml /conf/filebeat.yml && \
+	apk add libc6-compat && \
     rm -rf /var/cache/apk/* /root/${FILEBEAT_FILE}
 	
 VOLUME /conf
 VOLUME /logs
 
 ENTRYPOINT ["/opt/filebeat/filebeat", "-c", "/conf/filebeat.yml"]
+EXPOSE ${UDP_INTERNAL_PORT}


### PR DESCRIPTION
UP-493 - upgraded to 6.2.1, udp filebeat input supported